### PR TITLE
fix: cycle entities logic and structure update

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -107,9 +107,7 @@ type Cycle @entity(immutable: false) {
   id: Bytes!
   onDistributionPeriod: Boolean!
   currentCycleDuration: BigInt!
-  previousCycleDuration: BigInt!
   distributionDuration: BigInt!
-  previousCycleStart: BigInt!
   currentCycleStart: BigInt!
   rewardPerToken: [CycleRewardPerToken!] @derivedFrom(field: "cycle")
 }
@@ -126,6 +124,7 @@ type ContractConfig @entity(immutable: false) {
   backersManager: Bytes!
   builderRegistry: Bytes!
   rewardDistributor: Bytes!
+  distributingCycleId: Bytes!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   blockHash: Bytes!

--- a/schema.graphql
+++ b/schema.graphql
@@ -124,7 +124,6 @@ type ContractConfig @entity(immutable: false) {
   backersManager: Bytes!
   builderRegistry: Bytes!
   rewardDistributor: Bytes!
-  distributingCycleId: Bytes!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   blockHash: Bytes!

--- a/src/backersManager/rewardDistributionFinished.ts
+++ b/src/backersManager/rewardDistributionFinished.ts
@@ -1,7 +1,7 @@
 import { RewardDistributionFinished as RewardDistributionFinishedEvent } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { BackersManagerRootstockCollective as BackersManagerRootstockCollectiveContract } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
-import { loadOrCreateCycle, loadOrCreateGlobalMetric, updateBlockInfo } from "../utils";
-import { Bytes } from "@graphprotocol/graph-ts";
+import { CONTRACT_CONFIG_ID, DEFAULT_BYTES, loadOrCreateGlobalMetric, updateBlockInfo } from "../utils";
+import { ContractConfig, Cycle } from "../../generated/schema";
 
 export function handleRewardDistributionFinished(
   event: RewardDistributionFinishedEvent
@@ -9,14 +9,21 @@ export function handleRewardDistributionFinished(
   const backersManagerContract = BackersManagerRootstockCollectiveContract.bind(
     event.address
   );
-  const cycleStart = backersManagerContract.cycleStart(event.block.timestamp);
-  const cycle = loadOrCreateCycle(changetype<Bytes>(Bytes.fromBigInt(cycleStart)));
-  cycle.onDistributionPeriod = false;
-  cycle.save();
+
+  const contractConfig = ContractConfig.load(CONTRACT_CONFIG_ID);
+  if (contractConfig != null && !contractConfig.distributingCycleId.equals(DEFAULT_BYTES)) {
+    const cycle = Cycle.load(contractConfig.distributingCycleId);
+    if (cycle != null) {
+      cycle.onDistributionPeriod = false;
+      cycle.save();
+    }
+    contractConfig.distributingCycleId = DEFAULT_BYTES;
+    contractConfig.save();
+  }
 
   const globalMetric = loadOrCreateGlobalMetric();
   globalMetric.totalPotentialReward = backersManagerContract.totalPotentialReward();
   globalMetric.save();
 
-  updateBlockInfo(event, ["Cycle", "GlobalMetric"]);
+  updateBlockInfo(event, ["Cycle", "ContractConfig", "GlobalMetric"]);
 }

--- a/src/backersManager/rewardDistributionFinished.ts
+++ b/src/backersManager/rewardDistributionFinished.ts
@@ -1,7 +1,7 @@
 import { RewardDistributionFinished as RewardDistributionFinishedEvent } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { BackersManagerRootstockCollective as BackersManagerRootstockCollectiveContract } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
-import { CONTRACT_CONFIG_ID, DEFAULT_BYTES, loadOrCreateGlobalMetric, updateBlockInfo } from "../utils";
-import { ContractConfig, Cycle } from "../../generated/schema";
+import { DEFAULT_BYTES, loadOrCreateContractConfig, loadOrCreateGlobalMetric, updateBlockInfo } from "../utils";
+import { Cycle } from "../../generated/schema";
 
 export function handleRewardDistributionFinished(
   event: RewardDistributionFinishedEvent
@@ -10,8 +10,8 @@ export function handleRewardDistributionFinished(
     event.address
   );
 
-  const contractConfig = ContractConfig.load(CONTRACT_CONFIG_ID);
-  if (contractConfig != null && !contractConfig.distributingCycleId.equals(DEFAULT_BYTES)) {
+  const contractConfig = loadOrCreateContractConfig();
+  if (!contractConfig.distributingCycleId.equals(DEFAULT_BYTES)) {
     const cycle = Cycle.load(contractConfig.distributingCycleId);
     if (cycle != null) {
       cycle.onDistributionPeriod = false;

--- a/src/backersManager/rewardDistributionFinished.ts
+++ b/src/backersManager/rewardDistributionFinished.ts
@@ -19,5 +19,5 @@ export function handleRewardDistributionFinished(
   globalMetric.totalPotentialReward = backersManagerContract.totalPotentialReward();
   globalMetric.save();
 
-  updateBlockInfo(event, ["Cycle", "ContractConfig", "GlobalMetric"]);
+  updateBlockInfo(event, ["Cycle", "GlobalMetric"]);
 }

--- a/src/backersManager/rewardDistributionFinished.ts
+++ b/src/backersManager/rewardDistributionFinished.ts
@@ -1,7 +1,7 @@
 import { RewardDistributionFinished as RewardDistributionFinishedEvent } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { BackersManagerRootstockCollective as BackersManagerRootstockCollectiveContract } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
-import { DEFAULT_BYTES, loadOrCreateContractConfig, loadOrCreateGlobalMetric, updateBlockInfo } from "../utils";
-import { Cycle } from "../../generated/schema";
+import { Bytes } from "@graphprotocol/graph-ts";
+import { loadOrCreateCycle, loadOrCreateGlobalMetric, updateBlockInfo } from "../utils";
 
 export function handleRewardDistributionFinished(
   event: RewardDistributionFinishedEvent
@@ -10,16 +10,10 @@ export function handleRewardDistributionFinished(
     event.address
   );
 
-  const contractConfig = loadOrCreateContractConfig();
-  if (!contractConfig.distributingCycleId.equals(DEFAULT_BYTES)) {
-    const cycle = Cycle.load(contractConfig.distributingCycleId);
-    if (cycle != null) {
-      cycle.onDistributionPeriod = false;
-      cycle.save();
-    }
-    contractConfig.distributingCycleId = DEFAULT_BYTES;
-    contractConfig.save();
-  }
+  const cycleStart = backersManagerContract.cycleStart(event.block.timestamp);
+  const cycle = loadOrCreateCycle(changetype<Bytes>(Bytes.fromBigInt(cycleStart)));
+  cycle.onDistributionPeriod = false;
+  cycle.save();
 
   const globalMetric = loadOrCreateGlobalMetric();
   globalMetric.totalPotentialReward = backersManagerContract.totalPotentialReward();

--- a/src/backersManager/rewardDistributionRewards.ts
+++ b/src/backersManager/rewardDistributionRewards.ts
@@ -1,7 +1,7 @@
 import { RewardDistributionRewards as RewardDistributionRewardsEvent } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { BackersManagerRootstockCollective as BackersManagerRootstockCollectiveContract } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
-import { COINBASE_ADDRESS, CONTRACT_CONFIG_ID, loadOrCreateCycleRewardPerToken, updateBlockInfo } from "../utils";
-import { ContractConfig, Cycle } from "../../generated/schema";
+import { COINBASE_ADDRESS, loadOrCreateContractConfig, loadOrCreateCycleRewardPerToken, updateBlockInfo } from "../utils";
+import { Cycle } from "../../generated/schema";
 
 export function handleRewardDistributionRewards(
   event: RewardDistributionRewardsEvent
@@ -10,9 +10,7 @@ export function handleRewardDistributionRewards(
     event.address
   );
 
-  const contractConfig = ContractConfig.load(CONTRACT_CONFIG_ID);
-  if (contractConfig == null) return;
-
+  const contractConfig = loadOrCreateContractConfig();
   const cycle = Cycle.load(contractConfig.distributingCycleId);
   if (cycle == null) return;
 

--- a/src/backersManager/rewardDistributionRewards.ts
+++ b/src/backersManager/rewardDistributionRewards.ts
@@ -1,23 +1,20 @@
 import { RewardDistributionRewards as RewardDistributionRewardsEvent } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { BackersManagerRootstockCollective as BackersManagerRootstockCollectiveContract } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
-import { COINBASE_ADDRESS, loadOrCreateCycle, loadOrCreateCycleRewardPerToken, updateBlockInfo } from "../utils";
-import { Bytes } from "@graphprotocol/graph-ts";
+import { COINBASE_ADDRESS, CONTRACT_CONFIG_ID, loadOrCreateCycleRewardPerToken, updateBlockInfo } from "../utils";
+import { ContractConfig, Cycle } from "../../generated/schema";
 
 export function handleRewardDistributionRewards(
   event: RewardDistributionRewardsEvent
 ): void {
-
   const backersManagerContract = BackersManagerRootstockCollectiveContract.bind(
     event.address
   );
-  const currentCycleStart = backersManagerContract.cycleStart(event.block.timestamp);
 
-  const cycle = loadOrCreateCycle(changetype<Bytes>(Bytes.fromBigInt(currentCycleStart)));
-  cycle.onDistributionPeriod = true;
-  cycle.currentCycleStart = currentCycleStart;
-  cycle.currentCycleDuration = backersManagerContract.getCycleStartAndDuration().getValue1();
-  cycle.distributionDuration = backersManagerContract.distributionDuration();
-  cycle.save();
+  const contractConfig = ContractConfig.load(CONTRACT_CONFIG_ID);
+  if (contractConfig == null) return;
+
+  const cycle = Cycle.load(contractConfig.distributingCycleId);
+  if (cycle == null) return;
 
   const rifCycleRewardPerToken = loadOrCreateCycleRewardPerToken(backersManagerContract.rifToken(), cycle);
   rifCycleRewardPerToken.amount = event.params.rifAmount_;

--- a/src/backersManager/rewardDistributionRewards.ts
+++ b/src/backersManager/rewardDistributionRewards.ts
@@ -1,7 +1,7 @@
 import { RewardDistributionRewards as RewardDistributionRewardsEvent } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { BackersManagerRootstockCollective as BackersManagerRootstockCollectiveContract } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
-import { COINBASE_ADDRESS, loadOrCreateContractConfig, loadOrCreateCycleRewardPerToken, updateBlockInfo } from "../utils";
-import { Cycle } from "../../generated/schema";
+import { Bytes } from "@graphprotocol/graph-ts";
+import { COINBASE_ADDRESS, loadOrCreateCycle, loadOrCreateCycleRewardPerToken, updateBlockInfo } from "../utils";
 
 export function handleRewardDistributionRewards(
   event: RewardDistributionRewardsEvent
@@ -10,9 +10,8 @@ export function handleRewardDistributionRewards(
     event.address
   );
 
-  const contractConfig = loadOrCreateContractConfig();
-  const cycle = Cycle.load(contractConfig.distributingCycleId);
-  if (cycle == null) return;
+  const currentCycleStart = backersManagerContract.cycleStart(event.block.timestamp);
+  const cycle = loadOrCreateCycle(changetype<Bytes>(Bytes.fromBigInt(currentCycleStart)));
 
   const rifCycleRewardPerToken = loadOrCreateCycleRewardPerToken(backersManagerContract.rifToken(), cycle);
   rifCycleRewardPerToken.amount = event.params.rifAmount_;

--- a/src/backersManager/rewardDistributionStarted.ts
+++ b/src/backersManager/rewardDistributionStarted.ts
@@ -1,7 +1,7 @@
 import { RewardDistributionStarted as RewardDistributionStartedEvent } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { BackersManagerRootstockCollective as BackersManagerRootstockCollectiveContract } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { Bytes } from "@graphprotocol/graph-ts";
-import { loadOrCreateCycle, updateBlockInfo } from "../utils";
+import { loadOrCreateContractConfig, loadOrCreateCycle, updateBlockInfo } from "../utils";
 
 export function handleRewardDistributionStarted(
   event: RewardDistributionStartedEvent
@@ -18,5 +18,9 @@ export function handleRewardDistributionStarted(
   cycle.distributionDuration = backersManagerContract.distributionDuration();
   cycle.save();
 
-  updateBlockInfo(event, ["Cycle"]);
+  const contractConfig = loadOrCreateContractConfig();
+  contractConfig.distributingCycleId = cycle.id;
+  contractConfig.save();
+
+  updateBlockInfo(event, ["Cycle", "ContractConfig"]);
 }

--- a/src/backersManager/rewardDistributionStarted.ts
+++ b/src/backersManager/rewardDistributionStarted.ts
@@ -1,7 +1,7 @@
 import { RewardDistributionStarted as RewardDistributionStartedEvent } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { BackersManagerRootstockCollective as BackersManagerRootstockCollectiveContract } from "../../generated/BackersManagerRootstockCollective/BackersManagerRootstockCollective";
 import { Bytes } from "@graphprotocol/graph-ts";
-import { loadOrCreateContractConfig, loadOrCreateCycle, updateBlockInfo } from "../utils";
+import { loadOrCreateCycle, updateBlockInfo } from "../utils";
 
 export function handleRewardDistributionStarted(
   event: RewardDistributionStartedEvent
@@ -17,10 +17,6 @@ export function handleRewardDistributionStarted(
   cycle.currentCycleDuration = backersManagerContract.getCycleStartAndDuration().getValue1();
   cycle.distributionDuration = backersManagerContract.distributionDuration();
   cycle.save();
-
-  const contractConfig = loadOrCreateContractConfig();
-  contractConfig.distributingCycleId = cycle.id;
-  contractConfig.save();
 
   updateBlockInfo(event, ["Cycle", "ContractConfig"]);
 }

--- a/src/backersManager/rewardDistributionStarted.ts
+++ b/src/backersManager/rewardDistributionStarted.ts
@@ -18,5 +18,5 @@ export function handleRewardDistributionStarted(
   cycle.distributionDuration = backersManagerContract.distributionDuration();
   cycle.save();
 
-  updateBlockInfo(event, ["Cycle", "ContractConfig"]);
+  updateBlockInfo(event, ["Cycle"]);
 }

--- a/src/backersManager/v2/notifyReward.ts
+++ b/src/backersManager/v2/notifyReward.ts
@@ -8,11 +8,8 @@ export function handleNotifyReward(
 ): void {
   const backersManagerContract = BackersManagerRootstockCollectiveContract.bind(event.address);
   const nextCycleStart = backersManagerContract.cycleNext(event.block.timestamp);
-  const currentCycleStart = backersManagerContract.cycleStart(event.block.timestamp);
   const cycle = loadOrCreateCycle(changetype<Bytes>(Bytes.fromBigInt(nextCycleStart)));
 
-  cycle.previousCycleStart = currentCycleStart;
-  cycle.previousCycleDuration = backersManagerContract.getCycleStartAndDuration().getValue1();
   cycle.currentCycleStart = nextCycleStart;
   cycle.distributionDuration = backersManagerContract.distributionDuration();
   cycle.save();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,9 +60,7 @@ export function loadOrCreateCycle(cycleStart: Bytes): Cycle {
     cycle = new Cycle(cycleStart);
     cycle.onDistributionPeriod = false;
     cycle.currentCycleDuration = DEFAULT_BIGINT;
-    cycle.previousCycleDuration = DEFAULT_BIGINT;
     cycle.distributionDuration = DEFAULT_BIGINT;
-    cycle.previousCycleStart = DEFAULT_BIGINT;
     cycle.currentCycleStart = DEFAULT_BIGINT;
   }
 
@@ -165,6 +163,7 @@ export function loadOrCreateContractConfig(): ContractConfig {
     contractConfig.builderRegistry = ZERO_ADDRESS;
     contractConfig.rewardDistributor = ZERO_ADDRESS;
     contractConfig.backersManager = ZERO_ADDRESS;
+    contractConfig.distributingCycleId = DEFAULT_BYTES;
     contractConfig.blockNumber = DEFAULT_BIGINT;
     contractConfig.blockTimestamp = DEFAULT_BIGINT;
     contractConfig.blockHash = DEFAULT_BYTES;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,7 +163,6 @@ export function loadOrCreateContractConfig(): ContractConfig {
     contractConfig.builderRegistry = ZERO_ADDRESS;
     contractConfig.rewardDistributor = ZERO_ADDRESS;
     contractConfig.backersManager = ZERO_ADDRESS;
-    contractConfig.distributingCycleId = DEFAULT_BYTES;
     contractConfig.blockNumber = DEFAULT_BIGINT;
     contractConfig.blockTimestamp = DEFAULT_BIGINT;
     contractConfig.blockHash = DEFAULT_BYTES;


### PR DESCRIPTION
## What

- Updated subgraph logic in order to set the proper status for the `onDistributionPeriod` property on the cycle entity and removed `previousCycleDuration` and `previousCycleStart` properties because they're not being used

## Why

- wrong and/or unused properties

## Testing

- test in the graph playground after deploying a new subgraph

## Refs

- [tok-1146](https://rsklabs.atlassian.net/browse/TOK-1192?atlOrigin=eyJpIjoiOTlmYTUzMjIzN2Q3NDAyZmI1M2Q2YWNhNjU0YjM0N2MiLCJwIjoiaiJ9)
