### PR TITLE
fix(subgraph): accumulate cycle rewards instead of overwriting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rootstock-collective-subgraphs",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rootstock-collective-subgraphs",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "dependencies": {
         "@graphprotocol/graph-cli": "^0.98.1",
         "@graphprotocol/graph-ts": "^0.32.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rootstock-collective-subgraphs",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",

--- a/src/backersManager/rewardDistributionRewards.ts
+++ b/src/backersManager/rewardDistributionRewards.ts
@@ -14,15 +14,15 @@ export function handleRewardDistributionRewards(
   const cycle = loadOrCreateCycle(changetype<Bytes>(Bytes.fromBigInt(currentCycleStart)));
 
   const rifCycleRewardPerToken = loadOrCreateCycleRewardPerToken(backersManagerContract.rifToken(), cycle);
-  rifCycleRewardPerToken.amount = event.params.rifAmount_;
+  rifCycleRewardPerToken.amount = rifCycleRewardPerToken.amount.plus(event.params.rifAmount_);
   rifCycleRewardPerToken.save();
 
   const usdrifCycleRewardPerToken = loadOrCreateCycleRewardPerToken(backersManagerContract.usdrifToken(), cycle);
-  usdrifCycleRewardPerToken.amount = event.params.usdrifAmount_;
+  usdrifCycleRewardPerToken.amount = usdrifCycleRewardPerToken.amount.plus(event.params.usdrifAmount_);
   usdrifCycleRewardPerToken.save();
 
   const nativeCycleRewardPerToken = loadOrCreateCycleRewardPerToken(COINBASE_ADDRESS, cycle);
-  nativeCycleRewardPerToken.amount = event.params.nativeAmount_;
+  nativeCycleRewardPerToken.amount = nativeCycleRewardPerToken.amount.plus(event.params.nativeAmount_);
   nativeCycleRewardPerToken.save();
 
   updateBlockInfo(event, ["Cycle", "CycleRewardPerToken"]);


### PR DESCRIPTION
## What

Switch to `.plus()` so a follow-up zero-valued event is a no-op and the real cycle rewards are preserved. Matches the pattern already used in v2/notifyReward.ts.

## Why

The BackersManager contract can emit RewardDistributionRewards twice in the same cycle: once with the real distributed amounts, and again with zeros when a second startDistribution() falls into the short-circuit path after rewardsRif/Usdrif/Native have already been reset.

The handler was assigning `amount = event.params...`, so the second emission wiped the real values, leaving CycleRewardPerToken.amount at 0 and causing the frontend to render "Estimated Rewards 0.00 USD".

## Refs

taken as reference --> v2/notifyReward.ts.
